### PR TITLE
fix: proper refresh of dropdowns on graph regeneration (v2.1.6)

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,2 +1,2 @@
-__app_version__ = "2.1.5"
+__app_version__ = "2.1.6"
 __data_version__ = "2024-12-23"

--- a/static/js/dropdown.js
+++ b/static/js/dropdown.js
@@ -1,3 +1,33 @@
+export async function refreshDropdowns(authorsDropdown, worksDropdown) {
+    try {
+        const [authorsRes, worksRes] = await Promise.all([
+            fetch('/api/entities/authors'),
+            fetch('/api/entities/works')
+        ]);
+
+        const [optionsAuthors, optionsWorks] = await Promise.all([
+            authorsRes.json(),
+            worksRes.json()
+        ]);
+
+        authorsDropdown.empty();
+        worksDropdown.empty();
+
+        optionsAuthors.forEach(({ id, label }) => {
+            authorsDropdown.append(new Option(label, id));
+        });
+
+        optionsWorks.forEach(({ id, label }) => {
+            worksDropdown.append(new Option(label, id));
+        });
+
+        authorsDropdown.trigger('change');
+        worksDropdown.trigger('change');
+    } catch (error) {
+        console.error('Error refreshing dropdowns:', error);
+    }
+}
+
 document.addEventListener('DOMContentLoaded', async () => {
   try {
     // Fetch data for dropdowns

--- a/static/js/graph.js
+++ b/static/js/graph.js
@@ -1,3 +1,5 @@
+import { refreshDropdowns } from './dropdown.js';
+
 document.addEventListener('DOMContentLoaded', async () => {
     // Check if initialization parameters are provided by the backend
     const initialParams = window.initialParams || null;
@@ -208,8 +210,7 @@ function renderGraph(graph) {
             const authorsDropdown = $('#authors-dropdown');
             const worksDropdown = $('#works-dropdown');
 
-            authorsDropdown.empty(); // Clear authors dropdown
-            worksDropdown.empty(); // Clear works dropdown
+            await refreshDropdowns(authorsDropdown, worksDropdown);
 
             // Redo dropdown for the specific type
             if (d.type === 'author') {

--- a/templates/index.html
+++ b/templates/index.html
@@ -55,13 +55,13 @@
   </div>
 
   <!-- Dropdown Logic -->
-  <script src="{{ url_for('static', filename='js/dropdown.js') }}"></script>
+  <script type="module" src="{{ url_for('static', filename='js/dropdown.js') }}"></script>
 
   <!-- D3 Library -->
   <script src="https://d3js.org/d3.v7.min.js"></script>
 
   <!-- Graph Logic -->
-  <script src="{{ url_for('static', filename='js/graph.js') }}"></script>
+  <script type="module" src="{{ url_for('static', filename='js/graph.js') }}"></script>
 
   <script>
   // Utility function to fetch labels and populate dropdowns


### PR DESCRIPTION
After re-generating the graph on the fly, the dropdowns didn't have any options other than the ones that were already selected. In other words, the fully constructed option data was being lost.

The culprit was this is `graph.js`:
```
authorsDropdown.empty(); // Clear authors dropdown
worksDropdown.empty(); // Clear works dropdown
```

And sure enough, the Authors and Works dropdowns are showing this bug, but not the Exclude one. The fix was to replace this with the new `refreshDropdowns` function , defined in and imported from `dropdowns.js`.