### PR TITLE
feat: add force controls (v2.2.0)

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,2 +1,2 @@
-__app_version__ = "2.2.0-rc4"
+__app_version__ = "2.2.0"
 __data_version__ = "2024-12-23"

--- a/VERSION
+++ b/VERSION
@@ -1,2 +1,2 @@
-__app_version__ = "2.2.0-rc2"
+__app_version__ = "2.2.0-rc3"
 __data_version__ = "2024-12-23"

--- a/VERSION
+++ b/VERSION
@@ -1,2 +1,2 @@
-__app_version__ = "2.2.0-rc3"
+__app_version__ = "2.2.0-rc4"
 __data_version__ = "2024-12-23"

--- a/VERSION
+++ b/VERSION
@@ -1,2 +1,2 @@
-__app_version__ = "2.1.6"
+__app_version__ = "2.2.0-rc1"
 __data_version__ = "2024-12-23"

--- a/VERSION
+++ b/VERSION
@@ -1,2 +1,2 @@
-__app_version__ = "2.2.0-rc1"
+__app_version__ = "2.2.0-rc2"
 __data_version__ = "2024-12-23"

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -256,6 +256,18 @@ button:hover { background: #a93226; }
   padding: 5px;
 }
 
+#controls {
+  top: 10px;
+  left: 10px;
+  padding: 10px;
+  border-radius: 8px;
+}
+
+#controls label {
+  margin-bottom: 10px;
+  font-family: Arial, sans-serif;
+}
+
 #top-right-link {
   position: absolute;
   top: 10px;

--- a/static/js/graph.js
+++ b/static/js/graph.js
@@ -306,6 +306,13 @@ function renderGraph(graph) {
       simulation.alpha(0.3).restart();
   });
 
+  document.getElementById('centerStrength').addEventListener('input', function () {
+      const centerStrength = +this.value;
+      simulation.force('center', d3.forceCenter(width / 2, height / 2).strength(centerStrength));
+      simulation.alpha(0.3).restart(); // Restart with some energy
+  });
+
+
   simulation.on('tick', () => {
     link
       .attr('x1', d => d.source.x)

--- a/static/js/graph.js
+++ b/static/js/graph.js
@@ -287,6 +287,25 @@ function renderGraph(graph) {
     .attr('text-anchor', 'middle')
     .text(d => d.label);
 
+  // Add event listeners to update forces dynamically
+  document.getElementById('chargeStrength').addEventListener('input', function () {
+      const repulsionStrength = -this.value;
+      simulation.force('charge').strength(repulsionStrength);
+      simulation.alpha(0.3).restart();
+  });
+
+  document.getElementById('linkDistance').addEventListener('input', function () {
+      const linkDistance = +this.value;
+      simulation.force('link').distance(linkDistance);
+      simulation.alpha(0.3).restart();
+  });
+
+  document.getElementById('collisionRadius').addEventListener('input', function () {
+      const collisionRadius = +this.value;
+      simulation.force('collide').radius(collisionRadius);
+      simulation.alpha(0.3).restart();
+  });
+
   simulation.on('tick', () => {
     link
       .attr('x1', d => d.source.x)

--- a/static/js/graph.js
+++ b/static/js/graph.js
@@ -102,11 +102,18 @@ function renderGraph(graph) {
 
   svg.call(zoom);
 
+  // Fetch initial slider values dynamically
+  const initialLinkDistance = +document.getElementById('linkDistance').value;
+  const initialChargeStrength = -document.getElementById('chargeStrength').value; // Negative for repulsion
+  const initialCollisionRadius = +document.getElementById('collisionRadius').value;
+  const initialCenterStrength = 1;
+
+  // Initialize the simulation based on slider values
   const simulation = d3.forceSimulation(graph.nodes)
-    .force('link', d3.forceLink(graph.edges).id(d => d.id).distance(100))
-    .force('charge', d3.forceManyBody().strength(-100))
-    .force('center', d3.forceCenter(width / 2, height / 2))
-    .force('collide', d3.forceCollide(20));
+    .force('link', d3.forceLink(graph.edges).id(d => d.id).distance(initialLinkDistance))
+    .force('charge', d3.forceManyBody().strength(initialChargeStrength))
+    .force('center', d3.forceCenter(width / 2, height / 2).strength(initialCenterStrength))
+    .force('collide', d3.forceCollide(initialCollisionRadius));
 
   const link = graphGroup.append('g')
     .selectAll('line')

--- a/static/js/graph.js
+++ b/static/js/graph.js
@@ -175,7 +175,7 @@ function renderGraph(graph) {
       <ul class="nested-menu">
         <li><strong>${d.type.charAt(0).toUpperCase() + d.type.slice(1)} ID:</strong> ${d.id}</li>
         <li class="has-submenu">
-          <span>View in</span>
+          <span>View on</span>
           <ul class="submenu">
             <li><a href="https://www.panditproject.org/entity/${d.id}/${entityPath}" target="_blank">Pandit</a></li>
             <!-- Add more items here later -->
@@ -190,7 +190,7 @@ function renderGraph(graph) {
           </ul>
         </li>
         <li class="has-submenu">
-          <span>Emphasis</span>
+          <span>Exclusions</span>
           <ul class="submenu">
             <li><button id="collapse-btn">Collapse</button></li>
             <!-- <li><button id="remove-btn" disabled>Remove (Not Implemented)</button></li> -->

--- a/static/js/graph.js
+++ b/static/js/graph.js
@@ -319,6 +319,35 @@ function renderGraph(graph) {
       simulation.alpha(0.3).restart(); // Restart with some energy
   });
 
+  document.getElementById('freezeSwitch').addEventListener('change', function () {
+  if (this.checked) {
+    // Freeze: Disable all forces
+    simulation
+      .force('link', d3.forceLink().strength(0))
+      .force('charge', d3.forceManyBody().strength(0))
+      .force('center', d3.forceCenter(width / 2, height / 2).strength(0))
+        .force('collide', d3.forceCollide().strength(0))
+        .alpha(0)
+        .stop();
+    } else {
+      // Unfreeze: Reapply forces with current slider values
+      const linkDistance = +document.getElementById('linkDistance').value;
+      const chargeStrength = -document.getElementById('chargeStrength').value; // Negative for repulsion
+      const centerStrength = +document.getElementById('centerStrength').value;
+      const collisionRadius = +document.getElementById('collisionRadius').value;
+
+      simulation
+        .force('link', d3.forceLink(graph.edges).id(d => d.id).distance(linkDistance))
+        .force('charge', d3.forceManyBody().strength(chargeStrength))
+        .force('center', d3.forceCenter(width / 2, height / 2).strength(centerStrength))
+        .force('collide', d3.forceCollide(collisionRadius))
+        .alpha(1) // Reset the simulation's energy
+        .alphaDecay(0.0228) // Restore default decay
+        .restart(); // Restart the simulation
+    }
+  });
+
+
 
   simulation.on('tick', () => {
     link

--- a/templates/index.html
+++ b/templates/index.html
@@ -54,6 +54,21 @@
     <svg width="800" height="600"></svg>
   </div>
 
+  <div id="controls">
+    <label>
+      Repulsion Strength:
+      <input type="range" id="chargeStrength" min="0" max="2000" step="50" value="200">
+    </label>
+    <label>
+      Link Distance:
+      <input type="range" id="linkDistance" min="10" max="600" step="20" value="100">
+    </label>
+    <label>
+      Collision Radius:
+      <input type="range" id="collisionRadius" min="6" max="30" step="2" value="12">
+    </label>
+  </div>
+
   <!-- Dropdown Logic -->
   <script type="module" src="{{ url_for('static', filename='js/dropdown.js') }}"></script>
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -56,17 +56,23 @@
 
   <div id="controls">
     <label>
-      Repulsion Strength:
+      Charge:
       <input type="range" id="chargeStrength" min="0" max="2000" step="50" value="200">
     </label>
     <label>
-      Link Distance:
+      Link:
       <input type="range" id="linkDistance" min="10" max="600" step="20" value="100">
     </label>
     <label>
-      Collision Radius:
-      <input type="range" id="collisionRadius" min="6" max="30" step="2" value="12">
+      Collision:
+      <input type="range" id="collisionRadius" min="0" max="60" step="5" value="10">
     </label>
+    <label>
+      Center:
+      <input type="range" id="centerStrength" min="0" max=".1" step="0.01" value="0.005">
+    </label>
+</div>
+
   </div>
 
   <!-- Dropdown Logic -->

--- a/templates/index.html
+++ b/templates/index.html
@@ -55,20 +55,20 @@
   </div>
 
   <div id="controls">
-    <label>
-      Charge:
+    <label title="Controls how nodes repel each other globally. Higher values increase repulsion.">
+      Repulsion
       <input type="range" id="chargeStrength" min="0" max="2000" step="50" value="200">
     </label>
-    <label>
-      Link:
+    <label title="Controls how far apart connected nodes can spread. Higher values increase distance.">
+      Distance
       <input type="range" id="linkDistance" min="10" max="600" step="20" value="100">
     </label>
-    <label>
-      Collision:
-      <input type="range" id="collisionRadius" min="0" max="60" step="5" value="10">
+    <label title="Controls how strongly nodes refuse to overlap with local neighbors. Higher values increase virtual size.">
+      Radius
+      <input type="range" id="collisionRadius" min="0" max="30" step="3" value="12">
     </label>
-    <label>
-      Center:
+    <label title="Controls how strongly nodes try to return to center of graph. Higher values increase centralization.">
+      Center
       <input type="range" id="centerStrength" min="0" max=".1" step="0.01" value="0.005">
     </label>
 </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -71,7 +71,11 @@
       Center
       <input type="range" id="centerStrength" min="0" max=".1" step="0.01" value="0.005">
     </label>
-</div>
+    <label title="Temporarily disables all forces.">
+      Freeze
+      <input type="checkbox" id="freezeSwitch">
+    </label>
+  </div>
 
   </div>
 

--- a/templates/notes/updates.html
+++ b/templates/notes/updates.html
@@ -11,10 +11,11 @@
 
     <h1>Significant Past Updates</h1>
 
-    <p>January 2025 (0.0.0 – 2.1.4)</p>
+    <p>January 2025 (0.0.0 – 2.2.0)</p>
     <ul>
       <li>major refactor: 2024 data, ETL, API, D3, rebrand</li>
       <li>add context menu for nodes</li>
+      <li>add force controls</li>
     </ul>
 
     <h1>Ideas for Future Updates</h1>

--- a/utils/extract.py
+++ b/utils/extract.py
@@ -40,11 +40,8 @@ df_filtered["Authors (person)"] = df_filtered["Authors (person)"].fillna("").ast
 df_filtered["Author (person IDs)"] = df_filtered["Author (person IDs)"].str.replace(r";\s*;", ";", regex=True).str.strip("; ")
 df_filtered["Authors (person)"] = df_filtered["Authors (person)"].str.replace(r";\s*;", ";", regex=True).str.strip("; ")
 
-# Drop the "Content type" and "Attributed author" columns
+# Drop the "Content type" and two "Attributed author" columns
 df_filtered = df_filtered.drop(columns=["Content type", "Attributed author (person ID)", "Attributed author (person)"], errors="ignore")
-
-# Drop the "Content type" column
-df_filtered = df_filtered.drop(columns=["Content type"], errors="ignore")
 
 # Rename columns
 df_filtered.rename(columns={


### PR DESCRIPTION
Expose and explain four relevant forces (charge, link, collision, center).

Also add a freeze toggle that temporarily disables all.

Additional scout changes:
- Rename two context menu items
- Delete useless line in `extract.py`