### PR TITLE
fix: prevent work from having both author and attributed author (v2.4.7)

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,3 +1,3 @@
-__app_version__ = "2.4.6"
+__app_version__ = "2.4.7"
 __pandit_data_version__ = "2024-12-23"
 __seti_data_version__ = "2025-04-17"

--- a/data/2024-12-23-works-cleaned.csv
+++ b/data/2024-12-23-works-cleaned.csv
@@ -7310,7 +7310,7 @@ Person,87442,Kṛṣṇayya,,,,,,,,,
 Work,109721,Kṛṣṇīyam,Cintājñāna,,109720,Kṛṣṇācārya,Jyotiḥśāstra,,,1200,1200
 Work,96027,Kṛṣṇopaniṣad,,,,,,,,,
 Work,113057,Kr̥ṣṇotpatti,,,113056,Rāmdāsa,,,,,
-Work,109862,Kṛtprakaraṇa,,,40885; 41189,Vararuci; Śākatāyana,"Kātantra, Vyākaraṇa",,,,
+Work,109862,Kṛtprakaraṇa,,,40885,Vararuci,"Kātantra, Vyākaraṇa",,,,
 Work,41320,Kṛtyaratnāvalī,,,40259,Rāmacandra,Dharmaśāstra,,,1648,1648
 Person,86455,Kṣamākalyāṇagaṇi,,,,,,,,1772,1772
 Person,87443,Kṣamāśramaṇa,(Devavācaka) Kṣamāśramaṇa,,,,,,,,
@@ -10661,7 +10661,7 @@ Work,112892,Prastotṛprayoga,,,,,Veda,,,,
 Work,111232,Prātaḥ Stuti,,,,,Purāṇa,,,,
 Person,109897,Pratap Singh,Pratāpa Siṃha,Mahārāja,,,,,,1925,1848
 Work,41430,Pratāpakalpadruma,,,40488,Ananta,Vaidyaśāstra,,,,
-Work,108746,Pratāpamārtaṇḍa,"Prauḍhamārtaṇḍa, Kālanirṇayasaṅgraha",,40291; 40479,Rāmakṛṣṇa Bhaṭṭa; Pratāparudradeva Gajapati,Dharmaśāstra,,,,
+Work,108746,Pratāpamārtaṇḍa,"Prauḍhamārtaṇḍa, Kālanirṇayasaṅgraha",,40291,Rāmakṛṣṇa Bhaṭṭa,Dharmaśāstra,,,,
 Person,40421,Pratāpanārāyaṇa,,,,,,,,1700,1650
 Person,40478,Pratāpanṛpati,Pratāparāja,Devotee of Paraśurāma,,,,,,1550,1531
 Person,108747,Pratāparudra Kākatīya,Pratāparudra,,,,,,,1323,1296

--- a/data/2024-12-23-works-raw.csv
+++ b/data/2024-12-23-works-raw.csv
@@ -7327,7 +7327,7 @@ Person,87442,Kṛṣṇayya,,,,,,,,,
 Work,109721,Kṛṣṇīyam,Cintājñāna,,109720,Kṛṣṇācārya,Jyotiḥśāstra,,,1200,1200
 Work,96027,Kṛṣṇopaniṣad,,,,,,,,,
 Work,113057,Kr̥ṣṇotpatti,,,113056,Rāmdāsa,,,,,
-Work,109862,Kṛtprakaraṇa,,,40885; 41189,Vararuci; Śākatāyana,"Kātantra, Vyākaraṇa",,,,
+Work,109862,Kṛtprakaraṇa,,,40885,Vararuci,"Kātantra, Vyākaraṇa",,,,
 Work,41320,Kṛtyaratnāvalī,,,40259,Rāmacandra,Dharmaśāstra,,,1648,1648
 Person,86455,Kṣamākalyāṇagaṇi,,,,,,,,1772,1772
 Person,87443,Kṣamāśramaṇa,(Devavācaka) Kṣamāśramaṇa,,,,,,,,
@@ -10678,7 +10678,7 @@ Work,112892,Prastotṛprayoga,,,,,Veda,,,,
 Work,111232,Prātaḥ Stuti,,,,,Purāṇa,,,,
 Person,109897,Pratap Singh,Pratāpa Siṃha,Mahārāja,,,,,,1925,1848
 Work,41430,Pratāpakalpadruma,,,40488,Ananta,Vaidyaśāstra,,,,
-Work,108746,Pratāpamārtaṇḍa,"Prauḍhamārtaṇḍa, Kālanirṇayasaṅgraha",,40291; 40479,Rāmakṛṣṇa Bhaṭṭa; Pratāparudradeva Gajapati,Dharmaśāstra,,,,
+Work,108746,Pratāpamārtaṇḍa,"Prauḍhamārtaṇḍa, Kālanirṇayasaṅgraha",,40291,Rāmakṛṣṇa Bhaṭṭa,Dharmaśāstra,,,,
 Person,40421,Pratāpanārāyaṇa,,,,,,,,1700,1650
 Person,40478,Pratāpanṛpati,Pratāparāja,Devotee of Paraśurāma,,,,,,1550,1531
 Person,108747,Pratāparudra Kākatīya,Pratāparudra,,,,,,,1323,1296

--- a/data/2025-04-17-etext-link-data.json
+++ b/data/2025-04-17-etext-link-data.json
@@ -6969,19 +6969,19 @@
         }
     },
     "collection_total_link_counts": {
-        "GRETIL": 1037,
-        "SARIT": 75,
         "DCS": 257,
+        "GRETIL": 1037,
         "Muktabodha KSTS": 52,
-        "Vātāyana and Pramāṇa NLP": 45,
-        "Sanskrit Library and TITUS": 171
+        "SARIT": 75,
+        "Sanskrit Library and TITUS": 171,
+        "Vātāyana and Pramāṇa NLP": 45
     },
     "collection_missing_work_id_counts": {
-        "GRETIL": 266,
-        "SARIT": 11,
         "DCS": 95,
+        "GRETIL": 266,
         "Muktabodha KSTS": 5,
-        "Vātāyana and Pramāṇa NLP": 0,
-        "Sanskrit Library and TITUS": 68
+        "SARIT": 11,
+        "Sanskrit Library and TITUS": 68,
+        "Vātāyana and Pramāṇa NLP": 0
     }
 }

--- a/utils/extract.py
+++ b/utils/extract.py
@@ -37,10 +37,15 @@ df_filtered = df[columns_to_keep]
 # Further filter: Only keep rows where "Content type" is "Work" or "Person"
 df_filtered = df_filtered[df_filtered["Content type"].isin(["Work", "Person"])]
 
-# Combine "Attributed author (person ID)" into "Author (person IDs)"
+# Merge "Attributed author" into "Author"
+# If "Author" is empty, fill it with "Attributed author"
+# In rare cases where work has both, discard Attributed Author
 # TODO: eventually maintain this distinction
-df_filtered["Author (person IDs)"] = df_filtered["Author (person IDs)"].fillna("").astype(str) + "; " + df_filtered["Attributed author (person ID)"].fillna("").astype(str)
-df_filtered["Authors (person)"] = df_filtered["Authors (person)"].fillna("").astype(str) + "; " + df_filtered["Attributed author (person)"].fillna("").astype(str)
+
+df_filtered["Author (person IDs)"] = df_filtered["Author (person IDs)"].fillna("").astype(str)
+df_filtered.loc[df_filtered["Author (person IDs)"].str.strip() == "", "Author (person IDs)"] = df_filtered["Attributed author (person ID)"]
+df_filtered["Authors (person)"] = df_filtered["Authors (person)"].fillna("").astype(str)
+df_filtered.loc[df_filtered["Authors (person)"].str.strip() == "", "Authors (person)"] = df_filtered["Attributed author (person)"]
 
 # Clean up double separators and trailing separators
 df_filtered["Author (person IDs)"] = df_filtered["Author (person IDs)"].str.replace(r";\s*;", ";", regex=True).str.strip("; ")


### PR DESCRIPTION
There are only two cases where this happens, and I was concatenating the two for no good reason. Not an interesting issue, just something that was causing errors in unrelated experiments (on automating Pandit-Pāṇḍitya data refresh), so worth fixing.