### PR TITLE
chore: add quickstart tutorial (v2.5.1)

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,3 +1,3 @@
-__app_version__ = "2.5.0"
+__app_version__ = "2.5.1"
 __pandit_data_version__ = "2025-06-26"
 __seti_data_version__ = "2025-06-27"

--- a/templates/notes/technical.html
+++ b/templates/notes/technical.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
 </head>
 <body>
-  <div id="author-notes-container" class="shared-container">
+  <div id="technical-notes-container" class="shared-container">
 
     <h1>Technical Notes</h1>
 

--- a/templates/notes/updates.html
+++ b/templates/notes/updates.html
@@ -22,17 +22,23 @@
       <li>highlight works with online e-texts (SETI), add links in context menu</li>
       <li>add date, additional name, and discipline information</li>
     </ul>
+    <p>May - July 2025 (2.4.10 – 2.5.1)</p>
+    <ul>
+      <li>add two more corpora (UTA Dharmaśāstra, DCV)</li>
+      <li>refresh Pandit data (2025-06-26)</li>
+      <li>add tutorials page</li>
+    </ul>
 
     <h1>Ideas for Future Updates</h1>
 
     <p>Spring 2025</p>
     <ul>
-      <li>automate Pandit-Pāṇḍitya data refresh</li>
+      <li>improve Exclusions submenu: distinguish collapse/remove, add re-expand for collapsed</li>
+      <li>further automate Pandit-Pāṇḍitya data refresh</li>
+      <li>visualize family trees</li>
+      <li>search for related works with combination of discipline and date</li>
       <li>improve robustness of IAST handling with underlying SLP1</li>
       <li>add alphabetical browsing</li>
-      <li>search for related works with combination of discipline and date</li>
-      <li>visualize family trees</li>
-      <li>improve Exclusions submenu: distinguish collapse/remove, add re-expand for collapsed</li>
     </ul>
 
     <p>Summer 2025</p>

--- a/templates/notes/updates.html
+++ b/templates/notes/updates.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
 </head>
 <body>
-  <div id="author-notes-container" class="shared-container">
+  <div id="updates-notes-container" class="shared-container">
 
     <h1>Significant Past Updates</h1>
 

--- a/templates/seti.html
+++ b/templates/seti.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
 </head>
 <body>
-  <div id="data-notes-container" class="shared-container">
+  <div id="seti-container" class="shared-container">
     <h1>SETI</h1>
     <p>
       The Sanskrit E-Text Inventory (SETI)—or "Search for E-Textual Intelligence"—

--- a/templates/tutorials.html
+++ b/templates/tutorials.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
 </head>
 <body>
-  <div id="about-container" class="shared-container">
+  <div id="tutorials-container" class="shared-container">
     <h1>Presentation for 19th World Sanskrit Conference (June 2025)</h1>
 
     <video width="720" height="405" controls poster="/static/video/presentation-19wsc-poster.png">

--- a/templates/tutorials.html
+++ b/templates/tutorials.html
@@ -8,11 +8,21 @@
 </head>
 <body>
   <div id="tutorials-container" class="shared-container">
-    <h1>Presentation for 19th World Sanskrit Conference (June 2025)</h1>
 
+    <h1>Tutorial Videos</h1>
+
+    <h2 id="quickstart-video">Quickstart</h2>
+    <video width="720" height="405" controls poster="/static/video/quickstart-poster.png">
+      <source src="/static/video/quickstart.mp4" type="video/mp4">
+      Your browser does not support the video tag.
+    </video>
+
+    <br><br>
+
+    <h2 id="#full-presentationong-video">Presentation for 19th World Sanskrit Conference (June 2025)</h2>
     <video width="720" height="405" controls poster="/static/video/presentation-19wsc-poster.png">
-        <source src="/static/video/presentation-19wsc.mp4" type="video/mp4">
-        Your browser does not support the video tag.
+      <source src="/static/video/presentation-19wsc.mp4" type="video/mp4">
+      Your browser does not support the video tag.
     </video>
 
     <div class="footer">


### PR DESCRIPTION
Constructed shorter video out of longer video, added as primary (top).

Scout changes:
- updates
- container ids were improper copies e.g. of about